### PR TITLE
Add CI workflow for Jekyll build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: Build Jekyll site
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-ruby@v1
+      - run: bundle install --jobs 4 --retry 3
+      - run: bundle exec jekyll build


### PR DESCRIPTION
## Summary
- create `.github/workflows/build.yml` to run `bundle install` and `jekyll build`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ad4e76d80832b9a951d06bf122464